### PR TITLE
docs(readme): refresh marketplace root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,106 @@
-# Claude Code Plugin Marketplace
+# Young Leaders Tech Marketplace
 
-Personal marketplace for Claude Code plugins.
+A small, opinionated Claude Code plugin marketplace.
 
-## Available Plugins
+## What this is
 
-| Plugin | Description |
-|--------|-------------|
-| [skills-toolkit](./plugins/skills-toolkit/README.md) | Complete toolkit for creating, validating, and managing Claude Code skills |
+A personal marketplace shipping plugins for authoring Claude Code skills and agents,
+setting up a kitted macOS terminal in one shot, and refreshing READMEs across any kind
+of repo. Each plugin is self-contained with its own version, manifest, and README.
+Add the marketplace once and Claude Code picks up everything in `plugins/`.
 
-## Installing via Marketplace URL
+## Quick install
 
-Add this marketplace to Claude Code using the raw URL:
+Add this marketplace to Claude Code using the raw URL of `marketplace.json`:
 
-```
+```text
 https://github.com/YoungLeadersDotTech/young-leaders-tech-marketplace/raw/master/.claude-plugin/marketplace.json
 ```
 
-> **Note:** Use the `raw` URL, not the `blob` URL, or the marketplace will fail to load.
+> Use the `raw` URL, not the `blob` URL, or the marketplace fails to load.
 
-## Adding Plugins
+Then `/plugin install <name>` for whichever plugins you want.
 
-To add a plugin to this marketplace:
+## Available plugins
 
-1. Create your plugin directory under `plugins/`:
-   ```
-   plugins/your-plugin-name/
+| Plugin | Version | What it does |
+|---|---|---|
+| [skills-toolkit](./plugins/skills-toolkit/README.md) | 2.0.4 | Toolkit for authoring and validating Claude Code skills and agents. Ships `agent-author` (build / edit / package), `agent-validator` (cites `marketplace-guidelines.md` for findings), four shared skill templates, and 13 author and infrastructure templates. |
+| [terminal-setup-macos](./plugins/terminal-setup-macos/README.md) | 1.0.0 | Idempotent macOS terminal installer covering Ghostty, Oh My Zsh, Powerlevel10k, Glow, and MesloLGS Nerd Font, plus an optional markdown-preview kit (MacDown, grip, entr, OSC 8 clickable paths). Encodes the gotchas the original install guides got wrong. |
+| [update-readme](./plugins/update-readme/README.md) | 1.0.0 | Universal README updater. Scans the target, classifies repo type (plugin, marketplace, library, monorepo), asks detail level, then generates. Six-phase workflow with `Task*` tracking and `AskUserQuestion` gates at type confirmation, detail level, and write-or-dry-run. |
+
+## Browse and install via the helper script
+
+If you have the marketplace cloned locally:
+
+```bash
+./install-plugin.sh list
+./install-plugin.sh install skills-toolkit
+./install-plugin.sh install terminal-setup-macos
+./install-plugin.sh install update-readme
+```
+
+Each plugin's `install.sh` runs in `--global` mode by default.
+
+## Adding a plugin
+
+1. Create a new directory under `plugins/<name>/` with this layout:
+   ```text
+   plugins/<name>/
    ├── .claude-plugin/
    │   └── plugin.json
-   ├── commands/
-   ├── agents/
-   ├── skills/
-   └── README.md
+   ├── commands/         # optional
+   ├── agents/           # optional
+   ├── skills/           # optional
+   ├── README.md
+   └── VERSION
    ```
 
-2. Ensure `.claude-plugin/plugin.json` has the correct format:
+2. `plugin.json` requires the standard five fields plus arrays for whichever artefact
+   types you ship:
    ```json
    {
      "name": "your-plugin-name",
-     "description": "What this plugin does",
+     "description": "Clear description front-loading auto-invoke triggers. Max 250 chars. No em dashes. No forward slashes in description.",
      "author": {
-       "name": "Your Name",
-       "email": "your@email.com"
+       "name": "Young Leaders Tech",
+       "url": "https://youngleaders.tech"
      },
      "homepage": "https://github.com/YoungLeadersDotTech/young-leaders-tech-marketplace",
      "version": "1.0.0",
-     "commands": ["./commands/command-name.md"],
-     "agents": ["./agents/agent-name.md"],
-     "skills": ["./skills/skill-name"]
+     "commands": ["./commands/your-command.md"],
+     "agents": ["./agents/your-agent.md"],
+     "skills": ["./skills/your-skill"]
    }
    ```
 
-3. Register the plugin in `.claude-plugin/marketplace.json` at the repo root.
+3. Skills live directly under `plugins/<name>/skills/<skill>/` (flat layout).
+   The `~/.claude/skills/{personal, projects, shared}/` three-scope convention is
+   user-side only; do not mirror it in plugin source.
 
-4. Commit and push:
-   ```bash
-   git add plugins/your-plugin-name/ .claude-plugin/marketplace.json
-   git commit -m "Add your-plugin-name plugin"
-   git push
-   ```
+4. Register the plugin in `.claude-plugin/marketplace.json` at the repo root.
 
-## Plugin Requirements
+5. Open a PR. Once merged, run `/reload-plugins` to pick up the changes.
 
-All plugins must include:
-- `.claude-plugin/plugin.json` - Plugin manifest (5 core fields: name, description, author, homepage, version)
-- `README.md` - Documentation
-- `commands/`, `agents/`, and/or `skills/` directories as applicable
+For the full authoring + validation workflow with description quality scoring and PII
+checks, install `skills-toolkit` and use `/skills-toolkit:create-skill`.
 
-## Maintenance
+## Marketplace structure
 
-After adding or updating plugins, update `marketplace.json`:
-```bash
-# Edit .claude-plugin/marketplace.json to add/update plugin entries
+```text
+.claude-plugin/marketplace.json     # registry (semver, plugin entries)
+.marketplace-config.json            # extended metadata (categories, features)
+install-plugin.sh                   # browse + install helper
+plugins/
+├── skills-toolkit/
+├── terminal-setup-macos/
+└── update-readme/
+README.md                           # this file
 ```
+
+## Maintainer
+
+Young Leaders Tech &middot; <https://youngleaders.tech>
+
+<!-- Last verified: 2026-05-09 -->
+<!-- TODO: add LICENSE file at repo root (plugin READMEs reference MIT but no LICENSE file is committed) -->

--- a/README.md
+++ b/README.md
@@ -11,15 +11,40 @@ Add the marketplace once and Claude Code picks up everything in `plugins/`.
 
 ## Quick install
 
-Add this marketplace to Claude Code using the raw URL of `marketplace.json`:
+In Claude Code, add this marketplace once:
 
 ```text
-https://github.com/YoungLeadersDotTech/young-leaders-tech-marketplace/raw/master/.claude-plugin/marketplace.json
+/plugin marketplace add YoungLeadersDotTech/young-leaders-tech-marketplace
 ```
 
-> Use the `raw` URL, not the `blob` URL, or the marketplace fails to load.
+Then install whichever plugins you want by name:
 
-Then `/plugin install <name>` for whichever plugins you want.
+```text
+/plugin install skills-toolkit@young-leaders-tech-marketplace
+/plugin install terminal-setup-macos@young-leaders-tech-marketplace
+/plugin install update-readme@young-leaders-tech-marketplace
+```
+
+Or browse interactively:
+
+```text
+/plugin
+```
+
+After installing, run `/reload-plugins` to activate them in the current session.
+
+### Other ways to add the marketplace
+
+If GitHub shorthand isn't an option (e.g. private mirror):
+
+```text
+/plugin marketplace add git@github.com:YoungLeadersDotTech/young-leaders-tech-marketplace.git
+/plugin marketplace add https://github.com/YoungLeadersDotTech/young-leaders-tech-marketplace.git
+/plugin marketplace add ./local-clone-path           # for local dev
+/plugin marketplace add https://...marketplace.json  # direct JSON URL
+```
+
+Verify with `/plugin marketplace list`.
 
 ## Available plugins
 
@@ -29,18 +54,20 @@ Then `/plugin install <name>` for whichever plugins you want.
 | [terminal-setup-macos](./plugins/terminal-setup-macos/README.md) | 1.0.0 | Idempotent macOS terminal installer covering Ghostty, Oh My Zsh, Powerlevel10k, Glow, and MesloLGS Nerd Font, plus an optional markdown-preview kit (MacDown, grip, entr, OSC 8 clickable paths). Encodes the gotchas the original install guides got wrong. |
 | [update-readme](./plugins/update-readme/README.md) | 1.0.0 | Universal README updater. Scans the target, classifies repo type (plugin, marketplace, library, monorepo), asks detail level, then generates. Six-phase workflow with `Task*` tracking and `AskUserQuestion` gates at type confirmation, detail level, and write-or-dry-run. |
 
-## Browse and install via the helper script
+## Local development helper
 
-If you have the marketplace cloned locally:
+If you've cloned this marketplace and want to install a plugin straight from disk
+(useful while authoring), the bundled helper script wraps each plugin's own
+`install.sh`:
 
 ```bash
 ./install-plugin.sh list
 ./install-plugin.sh install skills-toolkit
-./install-plugin.sh install terminal-setup-macos
-./install-plugin.sh install update-readme
 ```
 
-Each plugin's `install.sh` runs in `--global` mode by default.
+Each plugin's `install.sh` runs in `--global` mode by default. This path is for
+local development; published consumers should use `/plugin marketplace add`
+above instead.
 
 ## Adding a plugin
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Add the marketplace once and Claude Code picks up everything in `plugins/`.
 
 ## Quick install
 
-In Claude Code, add this marketplace once:
+In Claude Code, add this marketplace once. **Use the SSH form** - the plugin
+marketplace install path requires SSH auth even if HTTPS works for everything else:
 
 ```text
-/plugin marketplace add YoungLeadersDotTech/young-leaders-tech-marketplace
+/plugin marketplace add git@github.com:YoungLeadersDotTech/young-leaders-tech-marketplace.git
 ```
 
 Then install whichever plugins you want by name:
@@ -33,16 +34,29 @@ Or browse interactively:
 
 After installing, run `/reload-plugins` to activate them in the current session.
 
+### "Permission denied (publickey)" when adding the marketplace?
+
+You don't have SSH auth set up for GitHub yet. The fix: run `gh auth login` once
+for HTTPS and once for SSH (pick the SSH protocol on the second run, accept the
+default key). HTTPS handles regular Git operations; SSH is what
+`/plugin marketplace add git@github...` actually uses.
+
+> HTTPS is used for regular Git operations. SSH is required for the plugin
+> marketplace install command (`/plugin marketplace add git@github...`). If you
+> skip SSH auth, you'll see "Permission denied (publickey)" when trying to
+> install plugins.
+>
+> - adapted from `FULL-SETUP-GUIDE.md` section 1.4
+
 ### Other ways to add the marketplace
 
-If GitHub shorthand isn't an option (e.g. private mirror):
-
-```text
-/plugin marketplace add git@github.com:YoungLeadersDotTech/young-leaders-tech-marketplace.git
-/plugin marketplace add https://github.com/YoungLeadersDotTech/young-leaders-tech-marketplace.git
-/plugin marketplace add ./local-clone-path           # for local dev
-/plugin marketplace add https://...marketplace.json  # direct JSON URL
-```
+| Form | Command | When |
+|---|---|---|
+| SSH (recommended above) | `/plugin marketplace add git@github.com:YoungLeadersDotTech/young-leaders-tech-marketplace.git` | Works once SSH auth is set up |
+| HTTPS git URL | `/plugin marketplace add https://github.com/YoungLeadersDotTech/young-leaders-tech-marketplace.git` | If you only have HTTPS auth and the marketplace download path doesn't trip on it |
+| GitHub shorthand | `/plugin marketplace add YoungLeadersDotTech/young-leaders-tech-marketplace` | Works when `gh` is authenticated |
+| Local path | `/plugin marketplace add ./local-clone-path` | For local development |
+| Direct JSON URL | `/plugin marketplace add https://github.com/YoungLeadersDotTech/young-leaders-tech-marketplace/raw/master/.claude-plugin/marketplace.json` | Fallback only |
 
 Verify with `/plugin marketplace list`.
 


### PR DESCRIPTION
## Summary

Refresh the marketplace root README so it actually reflects what's in the marketplace.

The previous README only listed `skills-toolkit` and used a generic "Personal marketplace for Claude Code plugins" tagline. After PR #5 (skills-toolkit v2.0.0 major), PR #8 (skills-toolkit v2.0.4 layout flatten), and the in-flight PRs #6 and #7, the README was three plugins behind reality.

## What's in the new README

- New title + tagline that names the marketplace
- "What this is" paragraph
- Quick-install section pointing at the canonical raw `marketplace.json` URL
- **Available plugins table with all 3 plugins**: skills-toolkit v2.0.4, terminal-setup-macos v1.0.0, update-readme v1.0.0
- Browse + install via `install-plugin.sh`
- Contributor guide for adding a plugin (now reflects the v2.0.4 flat skill layout, not the old `skills/shared/` wrapper)
- Top-level marketplace structure
- Maintainer + LICENSE TODO (plugin READMEs claim MIT but there's no LICENSE file at repo root yet)

## Methodology

Generated by following the update-readme skill's six-phase workflow manually. The skill itself ships in PR #7 and isn't installable yet, but I authored it so I ran the same protocol by hand:

1. **Context review** - parallel scan of marketplace.json, plugin manifests, install-plugin.sh, top-level layout, open PR state
2. **Type confirmation** - confirmed marketplace-root via AskUserQuestion (signals: `.claude-plugin/marketplace.json` at root, `plugins/` directory, `install-plugin.sh`)
3. **Detail level** - standard (around 150 lines)
4. **Generate** - routed on `<marketplace-root, standard>` into the section catalogue
5. **Preview and confirm** - validated em-dash count, version sync against marketplace.json, link resolution
6. **Write**

## Forward-looking links (deliberate)

Two of three plugin README links won't resolve on master at merge time:

- `./plugins/terminal-setup-macos/README.md` - lives in PR #6
- `./plugins/update-readme/README.md` - lives in PR #7

This is the explicit "list all 3, assume #6 and #7 land" choice. The README will be fully accurate the moment those PRs merge. If we instead wait to merge this README PR until after #6 and #7 land, no broken-link window exists.

## Suggested merge order

1. PR #6 (terminal-setup-macos)
2. PR #7 (update-readme)
3. **This PR** - all links resolve at merge time

Or merge this first and accept the temporary broken links until #6 / #7 land. Either is fine.

## Test plan

- [ ] Render README on GitHub, confirm table renders cleanly
- [ ] Click each plugin link (after #6 / #7 merge) - all 3 resolve
- [ ] Copy-paste the marketplace URL into Claude Code, `/plugin marketplace add`, all 3 plugins discoverable
- [ ] Run `./install-plugin.sh list` - matches the README plugin list

🤖 Generated with [Claude Code](https://claude.com/claude-code)