### PR TITLE
docs(skills-toolkit): bump README header v2.0.0 -> v2.0.4 + dedup version history

### DIFF
--- a/plugins/skills-toolkit/README.md
+++ b/plugins/skills-toolkit/README.md
@@ -1,6 +1,6 @@
 # Skills Toolkit for Claude Code
 
-**Version**: 2.0.0
+**Version**: 2.0.4
 **Author**: Young Leaders Tech
 **License**: MIT
 
@@ -515,23 +515,17 @@ Contributions welcome! Consider:
 
 ## Version History
 
-For full release notes see [CHANGELOG.md](./CHANGELOG.md).
+Current: **v2.0.4** (2026-05-09).
 
-### v2.0.0 (2026-05-08)
-- Added `agent-author` (merged from former agent-builder + agent-editor + agent-packager)
-- Added `agent-validator` (rewritten clean, cites marketplace-guidelines)
-- Added `references/marketplace-guidelines.md` ground-truth reference
-- Added 13 agent and infrastructure templates under `templates/`
-- Added `examples/` directory (sample-subagent + sample-portable-agent)
-- Migrated all `TodoWrite` references to `Task*` family across both validator agents
-- Trimmed all frontmatter descriptions to <=250 chars
-- Removed all employer-specific and project-specific terminology; replaced with generic placeholder names (Apollo, Acme Checkout) in examples
-- Fixed `stakeholder-templates` folder/name mismatch
-- Removed non-canonical `pattern: direct` from list-skills command
-- Eval committee score: 86.4/100; skill-validator: PASS on all 13 in-scope files
+For full release notes across all versions see [CHANGELOG.md](./CHANGELOG.md).
+Highlights:
 
-### v1.0.0 (2026-03-01)
-- Initial release: 2 agents, 3 commands, 4 shared skill templates
+- **v2.0.4** - flat plugin source layout (`skills/<name>/`, no more `skills/shared/` wrapper)
+- **v2.0.3** - alphabetised `plugin.json` arrays; `disable-model-invocation: true` on all four templates; cited Anthropic 250-char source in `marketplace-guidelines.md`
+- **v2.0.2** - canonical tools registry alignment in `agent-validator`; added missing `AskUserQuestion` to `skill-creator-agent`
+- **v2.0.1** - reverted (over-permissioning antipattern, see CHANGELOG)
+- **v2.0.0** - merged former agent-builder/editor/packager into `agent-author`, added `agent-validator`, `references/marketplace-guidelines.md`, 13 templates, `examples/`
+- **v1.0.0** - initial release
 
 ## License
 


### PR DESCRIPTION
## Summary

Surfaced during the version audit: the skills-toolkit plugin README still claims v2.0.0 even though the plugin is at v2.0.4 (per `VERSION`, `plugin.json`, `marketplace.json`, and CHANGELOG top entry). The embedded "Version History" section was also stale - only listed v2.0.0 + v1.0.0, missing 2.0.1 through 2.0.4.

## Changes

- `plugins/skills-toolkit/README.md` line 3: `**Version**: 2.0.0` -> `**Version**: 2.0.4`
- `plugins/skills-toolkit/README.md` "Version History" section: replace the duplicated v2.0.0 release notes with a tight highlights list covering v2.0.4 down to v1.0.0, with a pointer to `CHANGELOG.md` for full notes (single source of truth)

No frontmatter, no `allowed-tools`, no command/agent/skill content changes. Cosmetic plus dedup.

## Why this drifted

Each of PRs #5 (v2.0.0), the reverted v2.0.1, v2.0.2, v2.0.3, and #8 (v2.0.4) bumped `plugin.json`, `VERSION`, `marketplace.json`, and `CHANGELOG.md` but never touched the README header. Worth adding a CI check eventually that the README's `**Version**:` line matches `VERSION` - filed as a follow-up thought, not in this PR.

## Test plan

- [ ] Render README on GitHub, confirm v2.0.4 is shown at the top
- [ ] Click CHANGELOG.md link, confirm full release notes still resolve
- [ ] Diff confirms ONLY `plugins/skills-toolkit/README.md` changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)