### PR TITLE
docs(terminal-setup-macos): README and blog update for v1.2.0 clickable paths hook

### DIFF
--- a/plugins/terminal-setup-macos/README.md
+++ b/plugins/terminal-setup-macos/README.md
@@ -5,11 +5,7 @@ Glow, MesloLGS Nerd Font, plus an optional markdown-preview kit (MacDown 3000, g
 entr, OSC 8 clickable paths).
 
 The companion to the
-[**"Print this PDF, drop it in Claude Code, get a fully kitted terminal"** blog post](https://www.youngleaders.tech/p/7982b16d-9aa5-4281-b370-6647134cdf7d?postPreview=paid).
-<!-- TODO-DEEPLINK: blog post is currently a Substack draft preview URL. Replace
-with the canonical published URL `https://www.youngleaders.tech/terminal-setup-pdf-meta-guide`
-once the post is live. -->
-
+[**"Print this PDF, drop it in Claude Code, get a fully kitted terminal"** blog post](https://www.youngleaders.tech/p/terminal-setup-pdf-meta-guide).
 
 The blog post is the explainer with screenshots. This plugin is the executable. Both
 end at the same place; pick whichever entry point suits.
@@ -57,13 +53,44 @@ Then run the installer slash command:
    changed externally - the original MacDown requires close+reopen), registers it
    as the default `.md` handler using bundle ID `app.macdown.macdown3000`, adds
    `preview`, `mdwatch`, `mdls`, and `o` aliases.
-7. **Runs sanity tests** on the new shell config before declaring victory.
+7. **Wires the Claude Code PostToolUse hook** if you picked the Clickable file paths
+   extra: drops `post-bash-filename-links.py` into `~/.claude/hooks/` and patches
+   `~/.claude/settings.json` so every Bash tool result is scanned for bare filenames
+   and rewritten as OSC 8 links with the short name as display text — automatically,
+   with no manual `mdls` needed.
+8. **Runs sanity tests** on the new shell config before declaring victory.
+
+## Optional extras — what each one installs
+
+| Extra | What you get |
+|-------|-------------|
+| MacDown 3000 + .md handler | Native split-view markdown editor that auto-refreshes on external file edits; registered as default `.md` opener |
+| grip — live browser preview | `preview` alias → GitHub-flavoured localhost:6419 preview that reloads on save |
+| mdwatch — live terminal re-render | `mdwatch` alias → `entr` + `glow -p` re-renders the terminal preview on every save |
+| Clickable file paths | OSC 8 hyperlinks in Ghostty and other modern terminals; `mdls` and `o` shell aliases for manual use; **automatic Claude Code hook** that linkifies bare filenames in Bash tool output |
+
+## Clickable file paths — two modes
+
+**Automatic (Claude Code hook):** After install, every Bash tool result in Claude Code
+is scanned for bare filenames with known extensions (`.md`, `.yaml`, `.py`, `.ts`,
+etc.). Each one is resolved to an absolute path and rewritten as an OSC 8 hyperlink
+with the short filename as display text. A bare `btt-ai-ways-of-working-faq.md` in
+output becomes a short, clickable link — no full path printed.
+
+**Manual (shell aliases):** Outside of Claude Code, use:
+- `mdls [dir]` — list `.md` files in a directory as clickable terminal links
+- `o <file>` — print a clickable link and open the file
+
+Both modes use the same OSC 8 formatter at
+`~/.claude/global-utils/clickable-paths/format-clickable-path.js` and work in Ghostty,
+iTerm2, WezTerm, and VS Code's integrated terminal. They gracefully degrade to plain
+text in unsupported terminals or when `FORCE_HYPERLINK` is not set.
 
 ## Known gotchas the skill handles for you
 
 - This plugin uses **MacDown 3000** (cask `macdown-3000`), not the original
-  MacDown. The original does not auto-refresh on external file edits - close and
-  reopen the file is required - which breaks the "watch your agent edit live"
+  MacDown. The original does not auto-refresh on external file edits — close and
+  reopen the file is required — which breaks the "watch your agent edit live"
   use case. MacDown 3000 is a notarised fork (MIT, by Schuyler Erle) that refreshes
   live.
 - The MacDown 3000 bundle ID is `app.macdown.macdown3000`. The skill uses this and
@@ -78,13 +105,21 @@ Then run the installer slash command:
 - The Powerlevel10k wizard cannot run unattended; the skill installs the theme +
   plugin and instructs you to run `p10k configure` interactively in Ghostty after.
 - Parallel `brew install` calls cause portable-Ruby lock conflicts. Installs run sequentially.
+- `ghostty` is explicitly listed as a supported terminal in the OSC 8 formatter
+  (v1.2.0+). Set `FORCE_HYPERLINK=1` before launching Claude Code to force OSC 8
+  on any terminal.
 
 ## Troubleshooting
 
 If something goes wrong, your original `~/.zshrc` is at `~/.zshrc.pre-oh-my-zsh`.
 Restore with `mv ~/.zshrc.pre-oh-my-zsh ~/.zshrc && rm -rf ~/.oh-my-zsh`.
 
+If the Claude Code hook was installed but filenames aren't linking, check that
+`~/.claude/settings.json` contains a `PostToolUse > Bash` entry for
+`post-bash-filename-links.py`, and that `~/.claude/global-utils/clickable-paths/format-clickable-path.js`
+exists. Re-run `/terminal-setup-install` to repair either.
+
 ## Source material
 
-- Blog post (with screenshots): [link]
+- Blog post (with screenshots): [youngleaders.tech/p/terminal-setup-pdf-meta-guide](https://www.youngleaders.tech/p/terminal-setup-pdf-meta-guide)
 - Original install guide PDF, FAQ PDF: see the blog post for credits.

--- a/plugins/terminal-setup-macos/blog-update-clickable-paths.md
+++ b/plugins/terminal-setup-macos/blog-update-clickable-paths.md
@@ -1,0 +1,80 @@
+# Blog update — Clickable paths section (v1.2.0)
+
+Replace the entire **"Clickable paths"** section (from the `### Clickable paths`
+heading down to, but not including, the `* * *` divider before Troubleshooting)
+with the text below.
+
+---
+
+### Clickable paths
+
+> _Screenshot: a list of short .md filenames in a Bash tool result inside Claude Code — each one underlined and Cmd-clickable._
+
+Two modes, both using the same OSC 8 formatter at
+`~/.claude/global-utils/clickable-paths/format-clickable-path.js`.
+
+---
+
+**Mode 1: automatic (Claude Code hook)**
+
+This is the new thing in v1.2.0. When you pick this extra, the installer drops a
+PostToolUse hook into `~/.claude/hooks/` and wires it into `~/.claude/settings.json`.
+After that, every Bash tool result in Claude Code is scanned for bare filenames with
+known extensions (`.md`, `.yaml`, `.py`, `.ts`, `.json`, and more). Each one is
+resolved to an absolute path and rewritten as an OSC 8 hyperlink — but the short
+filename is the display text. So when Claude prints a summary table that says
+`btt-ai-ways-of-working-faq.md`, that's what you see: the short name, Cmd-clickable,
+no full path needed.
+
+Nothing to type. It just works.
+
+---
+
+**Mode 2: manual (shell aliases)**
+
+For use outside of Claude Code — in a plain terminal session. Add to `~/.zshrc`:
+
+```zsh
+mdls() {
+  local dir="${1:-.}"
+  local util="$HOME/.claude/global-utils/clickable-paths/format-clickable-path.js"
+  if [[ ! -f "$util" ]]; then
+    echo "format-clickable-path.js not found at $util" >&2
+    return 1
+  fi
+  for f in "$dir"/*.md(N); do
+    node -e "console.log(require('$util').formatClickablePathSafe('$(realpath "$f")'));"
+  done
+}
+
+o() {
+  if [[ -z "$1" ]]; then echo "usage: o <file>" >&2; return 1; fi
+  local util="$HOME/.claude/global-utils/clickable-paths/format-clickable-path.js"
+  local abs="$(realpath "$1" 2>/dev/null || echo "$1")"
+  if [[ -f "$util" ]]; then
+    node -e "console.log(require('$util').formatClickablePathSafe('$abs'));"
+  else
+    echo "$abs"
+  fi
+  open "$abs"
+}
+```
+
+Usage:
+
+```
+mdls            # list .md in current dir as clickable links
+mdls ~/docs     # same, but in a specific dir
+o README.md     # print clickable link + open in MacDown 3000
+```
+
+---
+
+**Terminal support**
+
+Works in Ghostty (explicitly supported from v1.2.0), iTerm2, WezTerm, and VS Code's
+integrated terminal. Falls back gracefully to plain text in terminals that don't support
+OSC 8 — no visual corruption. Set `FORCE_HYPERLINK=1` before launching Claude Code to
+force OSC 8 on any terminal.
+
+Best for: terminal-heavy workflows where you want to jump straight to a file without the copy-paste-open dance — and for Claude Code users who want filenames in agent output to be first-class clickable links.


### PR DESCRIPTION
## Summary

Follow-up to #13 (v1.2.0 feature). Documents the automatic Claude Code hook and updates the blog section.

### README changes
- Canonical blog post URL (no longer draft preview link)
- Step 7 added: describes the Claude Code PostToolUse hook installation
- New "Optional extras" table summarising all four extras at a glance
- New "Clickable file paths - two modes" section: automatic hook vs manual `mdls`/`o`
- Troubleshooting entry for the hook
- `ghostty` explicit support + `FORCE_HYPERLINK=1` note in gotchas

### Blog update
- `blog-update-clickable-paths.md` contains the drop-in replacement text for the "Clickable paths" section on the published post
- Splits into Mode 1 (automatic hook, new in v1.2.0) and Mode 2 (manual aliases)
- Updated screenshot caption, terminal support note, `FORCE_HYPERLINK` mention

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Blog replacement text applied at [youngleaders.tech/p/terminal-setup-pdf-meta-guide](https://www.youngleaders.tech/p/terminal-setup-pdf-meta-guide) — replace the `### Clickable paths` section with the content of `blog-update-clickable-paths.md`
- [ ] `blog-update-clickable-paths.md` can be deleted after the blog is updated (it's a staging file, not permanent docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)