### PR TITLE
fix(terminal-setup-macos): resolve all TODO-DEEPLINK entries to canonical Substack URLs

### DIFF
--- a/plugins/terminal-setup-macos/skills/terminal-setup-install/SKILL.md
+++ b/plugins/terminal-setup-macos/skills/terminal-setup-install/SKILL.md
@@ -166,29 +166,17 @@ export SDKMAN_DIR="$HOME/.sdkman"
 
 ### Step 9 - AskUserQuestion: optional extras
 
-<!-- TODO-DEEPLINKS: deep-link URLs below currently point to the Substack DRAFT
-preview. When the blog post is published, replace all four URLs with the
-canonical `/i/<post-id>/<heading-slug>` section URLs Substack emits for the
-published post. Each option below has its own TODO-DEEPLINK marker. Search this
-file for `TODO-DEEPLINK` to find every spot. -->
-
 Use this exact AskUserQuestion (multi-select):
 
 - **Question:** "Which optional markdown-preview extras would you like installed?"
 - **Header:** "MD extras"
 - **multiSelect:** `true`
 - **Options:**
-  1. **MacDown 3000 + .md handler** - Native macOS split-view markdown editor (notarised fork of MacDown that auto-refreshes when the file is changed externally). After install, double-clicking any .md in Finder opens it. <!-- TODO-DEEPLINK: replace draft URL when blog is published --> Deep link: `https://www.youngleaders.tech/p/7982b16d-9aa5-4281-b370-6647134cdf7d?postPreview=paid#macdown-3000`
-  2. **grip - live browser preview** - Serves a GitHub-flavoured preview at localhost:6419 and auto-reloads on save. <!-- TODO-DEEPLINK: replace draft URL when blog is published --> Deep link: `https://www.youngleaders.tech/p/7982b16d-9aa5-4281-b370-6647134cdf7d?postPreview=paid#grip`
-  3. **mdwatch - live terminal re-render** - Pairs entr with glow -p so the terminal preview re-renders the moment you save. <!-- TODO-DEEPLINK: replace draft URL when blog is published --> Deep link: `https://www.youngleaders.tech/p/7982b16d-9aa5-4281-b370-6647134cdf7d?postPreview=paid#mdwatch`
-  4. **Clickable file paths (mdls + o)** - OSC 8 hyperlinks in any modern terminal; mdls lists .md files as Cmd-clickable links. <!-- TODO-DEEPLINK: replace draft URL when blog is published --> Deep link: `https://www.youngleaders.tech/p/7982b16d-9aa5-4281-b370-6647134cdf7d?postPreview=paid#clickable-paths`
+  1. **MacDown 3000 + .md handler** - Native macOS split-view markdown editor (notarised fork of MacDown that auto-refreshes when the file is changed externally). After install, double-clicking any .md in Finder opens it. Screenshots and details: `https://www.youngleaders.tech/i/196949342/macdown-3000`
+  2. **grip - live browser preview** - Serves a GitHub-flavoured preview at localhost:6419 and auto-reloads on save. Screenshots and details: `https://www.youngleaders.tech/i/196949342/grip`
+  3. **mdwatch - live terminal re-render** - Pairs entr with glow -p so the terminal preview re-renders the moment you save. Screenshots and details: `https://www.youngleaders.tech/i/196949342/mdwatch`
+  4. **Clickable file paths (mdls + o)** - OSC 8 hyperlinks in any modern terminal; mdls lists .md files as Cmd-clickable links. Screenshots and details: `https://www.youngleaders.tech/i/196949342/clickable-paths`
 
-**TODO-DEEPLINKS - post-publish task:** the four URLs above are draft-preview
-links and will stop working once the post is published. After publish, capture
-the four section URLs (format: `https://www.youngleaders.tech/i/<numeric-post-id>/<heading-slug>`)
-and replace the four lines above. Substack section URLs are derived from heading
-text; the planned heading slugs are `macdown-3000`, `grip`, `mdwatch`,
-`clickable-paths`.
 
 ### Step 10 - Per-extra installs
 


### PR DESCRIPTION
## Summary

Blog post is live at https://www.youngleaders.tech/p/terminal-setup-pdf-meta-guide (post ID 196949342).

Replaces all four draft-preview deep link URLs with canonical section URLs and removes the TODO task block that was a placeholder for this update.

| Extra | Deep link |
|-------|-----------|
| MacDown 3000 | https://www.youngleaders.tech/i/196949342/macdown-3000 |
| grip | https://www.youngleaders.tech/i/196949342/grip |
| mdwatch | https://www.youngleaders.tech/i/196949342/mdwatch |
| Clickable file paths | https://www.youngleaders.tech/i/196949342/clickable-paths |

Also removes the now-redundant TODO-DEEPLINKS header comment and post-publish task block from SKILL.md (5 lines deleted, 4 canonical URLs added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)