### PR TITLE
rules: add AGENTS.md with OpenCode cross-runtime resolution block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# young-leaders-tech-marketplace - Instructions
+
+Claude Code skill/plugin marketplace. Auto-loaded when working anywhere in this repo,
+and read by OpenCode as the canonical rules file.
+
+## OpenCode cross-runtime resolution (added by opencode-sync)
+
+When you encounter these Claude Code tokens, resolve them yourself - OpenCode does not expand them automatically:
+
+- `${CLAUDE_PLUGIN_ROOT}` means `plugins/<that-plugin>/` from the repo root.
+- A `plugin:skill` reference (for example `Skill("plugin:skill")`) resolves to `plugins/<plugin>/skills/<skill>/SKILL.md`. Read it on a need-to-know basis, or invoke a discovered skill by its bare name via the skill tool.
+- Reference-only skills (denied in `permission.skill`) are not in the skill list - load them by reading their SKILL.md path directly when a body references them.


### PR DESCRIPTION
## What
Adds an AGENTS.md rules file (this repo had none), with a short header and the OpenCode cross-runtime resolution block.

## Why
AGENTS.md is the rules file OpenCode prefers, and Claude Code reads it too. The block lets OpenCode resolve `${CLAUDE_PLUGIN_ROOT}` and `plugin:skill` references and load reference-only skills by path, so this marketplace's plugin skills work under OpenCode.

## Notes
New docs-only file. No code or plugin behaviour changes.