### PR TITLE
config: expose plugin skills to OpenCode (skills.paths, enable-all)

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "skills": {
+    "paths": [
+      "plugins/skills-toolkit/skills",
+      "plugins/terminal-setup-macos/skills",
+      "plugins/update-readme/skills"
+    ]
+  }
+}


### PR DESCRIPTION
## What
Adds `opencode.json` with `skills.paths` pointing at every plugin's skills dir, so OpenCode discovers all plugin skills when working in this repo.

## Why
OpenCode does not look inside Claude Code plugin folders. `skills.paths` is the supported way to expose them - no symlinks, no copies, single-source. Generated by opencode-sync `ingest_source.py`.

## Notes
Enable-all: no `permission.skill` deny-list, so every skill is enabled for now - prune later by adding denies. Pairs with the AGENTS.md resolution block already on master.