### PR TITLE
feat(opencode-sync): memory wiring, skills-toolkit version sync gate, scrub public docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "young-leaders-tech-marketplace",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "description": "Personal Claude Code plugin marketplace",
   "owner": {
     "name": "Young Leaders Tech",

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Verify with `/plugin marketplace list`.
 | [update-readme](./plugins/update-readme/README.md) | 1.1.0 | Type-driven README updater. Detects repo family, confirms it with the user, asks for style, audience, and depth, then generates a matched README preview before writing. |
 | [standalone-skills](./plugins/standalone-skills/README.md) | 1.0.0 | Self-contained, Cowork-friendly skills with no cross-plugin dependencies. |
 | [opencode-sync](./plugins/opencode-sync/README.md) | 1.6.5 | Sync and validate Claude Code assets for OpenCode: ingest marketplaces or repos, generate agents and command wrappers, verify discovery coverage, and route MCP config by scope. |
-| [enablement-html-renderer](./plugins/enablement-html-renderer/README.md) | 1.2.3 | Packages finished enablement content into one self-contained HTML handoff with multiple reader-selectable formats. |
+| [enablement-html-renderer](./plugins/enablement-html-renderer/README.md) | 1.3.0 | Packages finished enablement content into one self-contained HTML handoff with multiple reader-selectable formats. |
 
 ## Local development helper
 

--- a/plugins/opencode-sync/CHANGELOG.md
+++ b/plugins/opencode-sync/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to the opencode-sync skill.
 - Hooks are now an explicit verification-only surface. Ingest reports them, but does not try to
   materialise them into OpenCode config.
 
+
 ## [1.6.2] - 2026-06-19
 
 ### Changed

--- a/plugins/opencode-sync/README.md
+++ b/plugins/opencode-sync/README.md
@@ -41,7 +41,16 @@ Activate it in the current session:
 /reload-plugins
 ```
 
-## Quick start
+**As a standalone skill folder.** `skills/opencode-sync/` is self-contained, so you can also
+use it without the plugin wrapper:
+
+- **Claude Code / OpenCode**: drop `skills/opencode-sync/` into `.claude/skills/` (or
+  `~/.claude/skills/`), or point OpenCode `skills.paths` at it. Both runtimes discover it
+  natively.
+- **Cowork**: zip the folder (root must be `opencode-sync/` with `SKILL.md` inside) and upload
+  it under Customize -> Skills.
+
+No PyYAML required - the scripts are stdlib Python 3 with a graceful fallback parser.
 
 Run the scripts from the marketplace repo root:
 
@@ -67,6 +76,21 @@ python3 plugins/opencode-sync/skills/opencode-sync/scripts/check_drift.py --chec
 
 If you use the skill standalone outside the plugin wrapper, the same scripts live under
 `skills/opencode-sync/scripts/` relative to that standalone skill folder.
+
+## Source Strategy
+
+When deciding what path to ingest, use this precedence:
+
+1. **Local development clone under `~/Projects/`** - use this when you are actively editing the plugin or marketplace. OpenCode should mirror the working tree you are changing, not a cached install snapshot.
+2. **Claude plugin cache under `~/.claude/plugins/cache/...`** - use this when you want exact parity with what Claude Code currently has installed. This is especially important for version-pinned installs and MCP-only plugins that do not have a normal marketplace checkout.
+3. **Fresh clone** - use this when you do not already have the source locally. Prefer a normal repo checkout (`~/Projects` or `~/.opencode-sources`) over editing the cache directly.
+
+Practical rule:
+
+- **Installed plugin parity** -> ingest from the Claude cache snapshot.
+- **Local development** -> ingest from the repo clone.
+
+The cache is the right source of truth for "what Claude has installed right now". A repo clone is the right source of truth for "what I am developing locally".
 
 ## Ingest behaviour
 

--- a/plugins/opencode-sync/skills/opencode-sync/scripts/ingest_source.py
+++ b/plugins/opencode-sync/skills/opencode-sync/scripts/ingest_source.py
@@ -570,6 +570,14 @@ def default_agent_out_dir(target_keys, explicit_out_dir):
     return ".opencode/agent"
 
 
+def wire_memory_instructions(root):
+    instructions = []
+    if (root / "MEMORY.md").exists():
+        instructions.append("MEMORY.md")
+    instructions.extend(["AGENTS.md", "~/.claude/memory/memory.md"])
+    return instructions
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("source", nargs="?", help="local path or git URL of the marketplace/plugin/repo")

--- a/plugins/opencode-sync/skills/opencode-sync/scripts/ingest_source.py
+++ b/plugins/opencode-sync/skills/opencode-sync/scripts/ingest_source.py
@@ -554,6 +554,22 @@ def wire_memory_instructions(root):
     return instructions
 
 
+def filter_units_by_enablement(units, enabled, disabled):
+    if enabled:
+        return [(n, sk) for (n, sk) in units if n in enabled and n not in disabled]
+    if disabled:
+        return [(n, sk) for (n, sk) in units if n not in disabled]
+    return list(units)
+
+
+def default_agent_out_dir(target_keys, explicit_out_dir):
+    if explicit_out_dir:
+        return explicit_out_dir
+    if "global" in target_keys:
+        return str(Path.home() / ".config" / "opencode" / "agent")
+    return ".opencode/agent"
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("source", nargs="?", help="local path or git URL of the marketplace/plugin/repo")
@@ -671,6 +687,8 @@ def main():
 
     agent_out_dir = default_agent_out_dir(target_keys or {args.config_target}, args.opencode_agent_dir)
     command_out_dir = default_command_out_dir(target_keys or {args.config_target}, args.opencode_command_dir)
+
+    agent_out_dir = default_agent_out_dir(target_keys or {args.config_target}, args.opencode_agent_dir)
 
     print(f"source: {root}  ({kind})")
     print(f"resolve: {note}")

--- a/plugins/opencode-sync/skills/opencode-sync/scripts/ingest_source.py
+++ b/plugins/opencode-sync/skills/opencode-sync/scripts/ingest_source.py
@@ -554,30 +554,6 @@ def wire_memory_instructions(root):
     return instructions
 
 
-def filter_units_by_enablement(units, enabled, disabled):
-    if enabled:
-        return [(n, sk) for (n, sk) in units if n in enabled and n not in disabled]
-    if disabled:
-        return [(n, sk) for (n, sk) in units if n not in disabled]
-    return list(units)
-
-
-def default_agent_out_dir(target_keys, explicit_out_dir):
-    if explicit_out_dir:
-        return explicit_out_dir
-    if "global" in target_keys:
-        return str(Path.home() / ".config" / "opencode" / "agent")
-    return ".opencode/agent"
-
-
-def wire_memory_instructions(root):
-    instructions = []
-    if (root / "MEMORY.md").exists():
-        instructions.append("MEMORY.md")
-    instructions.extend(["AGENTS.md", "~/.claude/memory/memory.md"])
-    return instructions
-
-
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("source", nargs="?", help="local path or git URL of the marketplace/plugin/repo")

--- a/plugins/update-readme/CHANGELOG.md
+++ b/plugins/update-readme/CHANGELOG.md
@@ -35,4 +35,4 @@ All notable changes to `update-readme` are documented here. Format follows [Keep
 ## [1.0.0] - 2026-05-10
 
 ### Added
-- Initial plugin: universal README updater that classifies repo type (plugin, marketplace, library, monorepo, service repo, personal), asks detail level, and generates a README using a section catalogue keyed on type plus detail level. `/update-readme` slash command and the `update-readme` skill.
+- Initial plugin: universal README updater that classifies repo type (plugin, marketplace, library, monorepo, service repo, personal), asks detail level, and generates a README using sections appropriate to the type. `/update-readme` slash command and the `update-readme` skill.


### PR DESCRIPTION
## Summary
- `opencode-sync` plugin: improved memory wiring reference doc, ingest script improvements, new tests
- `skills-toolkit`: codify version sync gate
- README, CI workflow, `.gitignore`, `.serena` config updates
- `enablement-html-renderer` version bump

These 3 commits predate recent PRs but were not squash-merged into master.

## Test plan
- [ ] Confirm `opencode-sync` tests pass
- [ ] Confirm marketplace.json versions are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)