### PR TITLE
chore: gitignore generated OpenCode sync artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ plugins/*/skills/*.zip
 .toast-build/
 __pycache__/
 *.pyc
+
+# Generated OpenCode sync output - regenerable from canonical sources, not source
+.opencode/
+.opencode-sync/


### PR DESCRIPTION
Ignore `.opencode/` and `.opencode-sync/` - regenerable output from the opencode-sync skill (generated agents/commands/MCP config + drift manifest), not source. Neither is currently tracked; this just stops them appearing as untracked in a synced checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)