### PR TITLE
skills-toolkit: fix README header/footer self-drift + stale 3.0.0 content

### DIFF
--- a/plugins/skills-toolkit/README.md
+++ b/plugins/skills-toolkit/README.md
@@ -1,538 +1,81 @@
 # Skills Toolkit for Claude Code
 
-**Version**: 3.1.0
-**Author**: Young Leaders Tech
-**License**: MIT
+Author and validate Claude Code skills and agents for this marketplace - with a real deterministic script doing the checking, not a model self-grading its own homework.
 
-## Overview
+## What it does
 
-`skills-toolkit` is the authoring + validation plugin for Claude Code skills and agents in this marketplace. As of 3.0.0 it ships a script-backed `skills-toolkit` skill (`skills/skills-toolkit/SKILL.md` + `scripts/validate_skills.py`) that creates and validates skills/agents via a real deterministic check, not a self-scored rubric - replacing the old `create-skill`, `list-skills`, and `validate-skill` command wrappers. It also still ships four agents (skill-creator, skill-validator, agent-author, agent-validator, kept for now), four reusable shared-skill templates, thirteen agent and infrastructure templates, a deterministic plugin version-sync gate, and a marketplace-guidelines reference doc. 3.1.0 adds a `Q8-VAGUE-ASK-USER` check and the canonical `references/askuserquestion-protocol.md` block, and fixes a manifest drift left over from 3.0.0 (`plugin.json` still listed the deleted commands and omitted the new skill).
+Building a skill or agent by hand means re-deriving the same rules every time: description length, PII, frontmatter shape, whether a "5-file rule" version bump actually happened. This plugin turns those rules into a script (`scripts/validate_skills.py`) that a skill runs and relays verbatim - so "does this pass?" has one real answer instead of a model's best guess. It also ships reusable templates for common skill types and agent/hook infrastructure, so new artefacts start from a working shape instead of a blank file.
 
-## What's Included
-
-### 4 Intelligent Agents
-
-#### skill-creator-agent
-Interactive guide for creating Claude Code skill files (SKILL.md):
-- 5-phase creation workflow
-- Description engineering (WHEN + WHEN NOT triggers, <=250-char cap)
-- PII validation
-- Template-based structure generation
-- Task* progress tracking
-
-#### skill-validator-agent
-Read-only professional validator for skills:
-- YAML frontmatter and markdown structure
-- Description quality scoring
-- PII detection (emails, phones, secrets)
-- Claude Code ecosystem compatibility
-
-#### agent-author (NEW in 2.0.0)
-End-to-end agent authoring with three modes selected via AskUserQuestion at session start:
-- `create`: build a new subagent from scratch
-- `edit`: modify an existing agent file
-- `package`: bundle a validated agent with install.sh and MANIFEST.json
-Six-phase lifecycle (Analyse, Design, Generate, Bundle, Validate, Document). Replaces the legacy three-agent agent-builder + agent-editor + agent-packager chain.
-
-#### agent-validator (NEW in 2.0.0)
-Validates Claude Code subagent files against `references/marketplace-guidelines.md`. Six-phase lifecycle. Reports findings with severity (BLOCKER, WARNING, INFO) and section citation. Auto-detects bundle and plugin context for cross-file consistency checks.
-
-### 3 Slash Commands
-
-#### `/create-skill`
-Launch the interactive skill creation workflow:
-```
-/create-skill stakeholder
-/create-skill ground-truth
-/create-skill product
-/create-skill initiative
-```
-
-The skill-creator-agent guides you through requirements gathering, description engineering, structure generation, and validation.
-
-#### `/validate-skill`
-Validate existing skills for quality and security:
-```
-/validate-skill /path/to/SKILL.md
-```
-
-Get comprehensive reports with:
-- Structure validation (YAML, markdown)
-- Content quality scoring
-- PII detection results
-- Actionable recommendations
-- Severity classifications (PASS/NEEDS IMPROVEMENT/FAIL)
-
-#### `/list-skills`
-Discover available skills organized by scope:
-```
-/list-skills
-```
-
-Shows personal, project, and shared skills with metadata.
-
-### 4 Shared Skill Templates (`skills/`)
-
-Reusable scaffolds for new skills you author. Each ships description-engineering guidance, placeholder structures, validation checklists, security guidelines, and worked examples.
-
-#### Stakeholder Template
-For team/person context on specific projects:
-- Roles, goals, pain points
-- Communication preferences
-- Decision-making patterns
-
-#### Ground Truth Template
-For verifiable, canonical reference documentation:
-- Canonical definitions
-- Verified facts and metrics
-- Process flows and state machines
-- Validation criteria
-- Error codes and messages
-
-#### Product Context Template
-For product vision, goals, and constraints:
-- Vision and mission
-- Target users and personas
-- Goals and success metrics
-- Features and capabilities
-- UX principles
-
-#### Initiative Overview Template
-For cross-functional initiative coordination:
-- Charter and scope
-- Work streams and milestones
-- Cross-team coordination
-- Dependencies and risks
-- Status tracking
-
-### 13 Agent and Infrastructure Templates (`templates/`)
-
-Ready-to-crib templates `agent-author` consumes during create / package modes:
-
-| Template | Purpose |
-|---|---|
-| `claude-subagent-template.md` | Canonical agent .md frontmatter + body skeleton |
-| `portable-agent-template.md` | Standalone agent for use outside a plugin |
-| `install-script-template.sh` | Smart install.sh with --global / --project / --sync-back |
-| `bundle-readme-template.md` | Auto-generated bundle README |
-| `hook-template.sh` | Generic hook skeleton |
-| `hook-sessionstart-template.sh` | SessionStart hook |
-| `hook-pretooluse-template.sh` | PreToolUse hook |
-| `hook-posttooluse-template.sh` | PostToolUse hook |
-| `agent-coordination-template.md` | Multi-agent coordination patterns |
-| `change-propagation-guide-template.md` | Versioning across cross-agent dependencies |
-| `agent-builder-logging-template.md` | Logging skeleton for agent operations |
-| `validation-checklist-template.md` | Reusable validation gates |
-| `structured-choice-template.md` | AskUserQuestion patterns |
-
-### Reference: `references/marketplace-guidelines.md`
-
-Single ground-truth doc that `agent-validator` and `skill-validator-agent` cite. Codifies:
-- 5-file rule (CHANGELOG, VERSION, plugin.json, marketplace.json, README)
-- Semver decision table
-- Same-commit ordering rule
-- Two version fields (top-level + plugin entry)
-- CHANGELOG format (Keep a Changelog)
-- Frontmatter description cap (<=250 chars)
-- Em-dash ban (U+2014)
-- Migration pattern (global skill -> plugin skill)
-- Claude Code plugin schema reference
-- Severity taxonomy (BLOCKER / WARNING / INFO)
-
-### Script: `scripts/check_plugin_version_sync.py`
-
-The validator surface now includes a deterministic 5-file gate for marketplace plugins. The script checks:
-- `plugins/<name>/VERSION`
-- `plugins/<name>/CHANGELOG.md`
-- `plugins/<name>/.claude-plugin/plugin.json`
-- `.claude-plugin/marketplace.json` plugin entry
-- `plugins/<name>/README.md` version header line
-
-When you pass `--prev-marketplace`, it also asserts the top-level marketplace version advanced in the same change. `agent-validator` uses this script first for plugin-bound artefacts, then falls back to the manual checklist only if the script is unavailable.
-
-### Examples (`examples/`)
-
-- `sample-subagent.md`: a minimal working agent file you can copy and rename.
-- `sample-portable-agent/`: a standalone agent bundle (instructions + README).
-
-## Install
-
-In Claude Code, add the marketplace once (SSH form - see [root README](../../README.md#quick-install) for HTTPS and other options):
+## Getting started
 
 ```text
 /plugin marketplace add git@github.com:YoungLeadersDotTech/young-leaders-tech-marketplace.git
-```
-
-Then install this plugin:
-
-```text
 /plugin install skills-toolkit@young-leaders-tech-marketplace
-```
-
-Activate in the current session:
-
-```text
 /reload-plugins
 ```
 
-### Verify install
+Then just ask for what you want - "create a skill for X" or "validate this SKILL.md" - the `skills-toolkit` skill picks it up automatically. See its own `SKILL.md` for the exact trigger phrases.
 
-```text
-/list-skills
-```
+## Skills
 
-You should see the four shared skill templates plus the plugin's commands and agents available.
+| Skill | Description |
+|-------|-------------|
+| `skills-toolkit` | Create and validate SKILL.md and agent `.md` files. Runs `scripts/validate_skills.py` (description-cap, PII, em-dash, frontmatter shape, Task* completeness, command-wrapper detection) and relays real findings - never a self-scored rubric. |
+| `stakeholder-templates` | Scaffold for team/person context skills - roles, goals, pain points, communication preferences. |
+| `ground-truth-template` | Scaffold for canonical reference documentation - verified facts, process flows, error codes. |
+| `product-context-template` | Scaffold for product vision/goals/constraints skills - target users, features, UX principles. |
+| `initiative-overview-template` | Scaffold for cross-functional initiative coordination - charter, work streams, dependencies. |
 
-## Quick Start
+## Agents (legacy, kept for now)
 
-### Create Your First Skill
+Four prose-based agents predate the script-backed `skills-toolkit` skill and are still installed - their command-wrapper entry points (`/create-skill`, `/validate-skill`, `/list-skills`) were removed in 3.0.0, but the agent files themselves were not superseded:
 
-```
-/create-skill stakeholder
-```
+- **skill-creator-agent** - interactive skill creation walkthrough
+- **skill-validator-agent** - read-only skill validator (prose-based; use the `skills-toolkit` skill's script-backed validation instead for a verifiable result)
+- **agent-author** - agent creation/edit/package modes
+- **agent-validator** - agent validation against `references/marketplace-guidelines.md`
 
-The skill-creator-agent will guide you through:
-1. **Requirements Gathering** - Define skill name, scope, and purpose
-2. **Description Engineering** - Craft WHEN/WHEN NOT triggers
-3. **Structure Generation** - Generate SKILL.md with proper format
-4. **Validation** - Check for PII, quality, and security
-5. **Finalization** - Get complete, ready-to-use SKILL.md
+New work should go through the `skills-toolkit` skill. These agents are not yet on a removal date.
 
-### Validate Existing Skills
-
-```
-/validate-skill ~/.claude/skills/projects/my-project/SKILL.md
-```
-
-Get a comprehensive report:
-- Overall status (PASS/NEEDS IMPROVEMENT/FAIL)
-- Detailed findings by domain
-- Actionable recommendations
-- Severity classifications
-
-### Browse Available Skills
+## Architecture
 
 ```
-/list-skills
+plugins/skills-toolkit/
+  skills/skills-toolkit/       # primary interface - script-backed create + validate
+    SKILL.md
+    scripts/validate_skills.py
+  skills/{stakeholder,ground-truth,product-context,initiative-overview}-templates/
+  agents/                      # legacy prose-based agents (see above)
+  templates/                   # 13 ready-to-crib agent/hook/infra templates
+  references/
+    marketplace-guidelines.md  # 5-file rule, semver table, severity taxonomy
+    to-scale-prototype-showcase.md
+  scripts/check_plugin_version_sync.py  # deterministic 5-file version-sync gate
+  examples/                    # sample-subagent.md, sample-portable-agent/
 ```
 
-See all your skills organized by:
-- Personal skills (`~/.claude/skills/personal/`)
-- Project skills (`.claude/skills/projects/`)
-- Shared templates (`.claude/skills/`)
+### Templates (`templates/`)
 
-## Key Features
+Ready-to-crib scaffolds `agent-author` consumes during create/package modes: canonical subagent and portable-agent skeletons, an install-script template (`--global`/`--project`/`--sync-back`), a bundle README template, four hook templates (generic, SessionStart, PreToolUse, PostToolUse), an agent-coordination pattern doc, a change-propagation guide, a logging skeleton, a validation-checklist template, and a structured-choice (`AskUserQuestion`) template.
 
-### Description Engineering
+### `references/marketplace-guidelines.md`
 
-The toolkit guides you to create high-quality skill descriptions with:
+The single ground-truth doc `agent-validator` and `skill-validator-agent` cite: 5-file rule, semver decision table, same-commit ordering rule, CHANGELOG format (Keep a Changelog), description cap (<=250 chars), em-dash ban, migration pattern (global skill -> plugin skill), and the BLOCKER/WARNING/INFO severity taxonomy.
 
-**WHEN Triggers** - Specific terms users will mention:
-- Project/product names
-- Domain keywords
-- Use case terms
+### `scripts/check_plugin_version_sync.py`
 
-**WHEN NOT Exclusions** - Prevent contamination:
-- Related but different projects
-- General discussions
-- Other teams/products
+A deterministic 5-file gate for marketplace plugins - checks `VERSION`, `CHANGELOG.md`, `plugin.json`, the marketplace.json entry, and the README version header all agree. `agent-validator` runs this first for plugin-bound artefacts, falling back to a manual checklist only if the script is unavailable.
 
-**Example**:
-```yaml
-description: Stakeholder context for Apollo UX research when discussing user testing, research synthesis, or design validation. Auto-invoke when user mentions Apollo, UX research stakeholders, or design team. Do NOT load for general UX discussions unrelated to Apollo.
-```
+## How validation works
 
-### PII Protection
+`validate_skills.py` checks description length/PII/em-dash/frontmatter shape and Task* completeness against real code, not model judgment - `skills-toolkit` relays its findings and exit code verbatim rather than inventing a PASS/FAIL verdict. `Q8-VAGUE-ASK-USER` (added 3.1.0) additionally flags "ask the user" prose with no real `AskUserQuestion` behind it, using `references/askuserquestion-protocol.md` as the canonical structured-question shape.
 
-Automatic detection of:
-- Email addresses
-- Phone numbers
-- SSN/sensitive identifiers
-- Personal names (contextual)
+## Development
 
-All templates include security checklists to ensure zero PII in skill content.
+No test suite ships with this plugin yet - validate changes by running `scripts/validate_skills.py` and `scripts/check_plugin_version_sync.py` directly against the plugin's own files before committing.
 
-### Quality Validation
+## Version
 
-Multi-domain validation:
-1. **Structure**: YAML frontmatter, markdown formatting
-2. **Content**: Clarity, completeness, professionalism
-3. **Technical**: Tool selection, capabilities, error handling
-4. **Security**: PII detection, confidential data, allowed-tools
+**Version**: 3.1.0
 
-### Hybrid Pattern Architecture
-
-Commands follow the proven hybrid pattern:
-- **Agents analyze**: Read files, validate, generate recommendations
-- **Main Claude executes**: Write files, display reports, apply fixes
-- **Clear separation**: Agent analyzes → Main Claude executes → Changes happen
-
-## Usage Examples
-
-### Example 1: Create Stakeholder Skill
-
-```
-User: /create-skill stakeholder
-
-skill-creator-agent: Let's create a stakeholder skill. What project is this for?
-
-User: Apollo UX Research
-
-skill-creator-agent: Great! What specific areas should this skill cover?
-
-User: User testing, research synthesis, design validation
-
-skill-creator-agent: Perfect. What terms should trigger this skill?
-
-User: Apollo, UX research, design team
-
-[Agent guides through description engineering, structure generation, validation]
-
-skill-creator-agent: ✅ Skill creation complete!
-File: .claude/skills/projects/apollo/stakeholders/SKILL.md
-Validation: PASSED (95/100)
-
-Main Claude: [Writes SKILL.md file to specified location]
-```
-
-### Example 2: Validate Before Production
-
-```
-User: /validate-skill .claude/skills/projects/apollo/stakeholders/SKILL.md
-
-skill-validator-agent:
-================================================================================
-SKILL VALIDATION REPORT
-================================================================================
-
-Overall Status: ✓ PASS
-
-Structure: ✓ PASS
-Content Quality: ✓ PASS (92/100)
-Security: ✓ PASS (Zero PII detected)
-Integration: ✓ PASS
-
-Recommendation: Production-ready. Optional improvements available.
-================================================================================
-```
-
-### Example 3: Browse All Skills
-
-```
-User: /list-skills
-
-Output:
-Personal Skills (2):
-└── user-manual/ - Work preferences and communication style
-└── learning-goals/ - Current learning objectives
-
-Project Skills (3):
-└── apollo/stakeholders/ - Apollo UX research team context
-└── checkout/ground-truth/ - Payment processing error codes
-└── pricing/initiative/ - Pricing innovation initiative overview
-
-Shared Templates (4):
-└── stakeholder-templates/ - Template for stakeholder skills
-└── ground-truth-template/ - Template for ground truth skills
-└── product-context-template/ - Template for product context skills
-└── initiative-overview-template/ - Template for initiative skills
-```
-
-## Best Practices
-
-### When to Use Each Template
-
-**Stakeholder Template**: Use when you need context about specific teams, roles, or people on a project
-- Team objectives and decision patterns
-- Communication preferences
-- Pain points and success metrics
-
-**Ground Truth Template**: Use for verifiable facts and canonical reference data
-- Error codes and definitions
-- Process flows and state machines
-- Validation criteria and business rules
-- Metrics and verified facts
-
-**Product Context Template**: Use for product vision and strategic context
-- Product goals and constraints
-- Target users and personas
-- Feature capabilities
-- UX principles
-
-**Initiative Template**: Use for cross-functional coordination
-- Initiative charters and scope
-- Work streams and milestones
-- Dependencies and risks
-- Status tracking
-
-### Description Quality Tips
-
-**DO**:
-- ✅ Include specific trigger terms
-- ✅ Add explicit WHEN NOT boundaries
-- ✅ Use possessive pronouns for personal skills
-- ✅ Quantify metrics (">95% accuracy" not "high accuracy")
-
-**DON'T**:
-- ❌ Use generic descriptions ("Provides information about...")
-- ❌ Skip WHEN NOT exclusions
-- ❌ Include PII (names, emails, phones)
-- ❌ Mix scopes (keep personal/project/shared separate)
-
-### Security Guidelines
-
-**Always**:
-- Use roles instead of names ("Product Owner" not "Jane Smith")
-- Use placeholders for sensitive data (`[STAKEHOLDER_NAME]`)
-- Set `allowed-tools: []` for reference skills
-- Review skills for business-confidential information
-
-**Never**:
-- Include emails, phone numbers, or SSN
-- Include specific revenue/budget numbers
-- Include unreleased features or roadmaps
-- Mix personal information with team context
-
-## Troubleshooting
-
-### Agent Not Responding
-
-**Problem**: Agent doesn't respond to tag
-**Solution**:
-```bash
-# Verify installation
-ls ~/.claude/agents/skill-creator-agent.md
-ls ~/.claude/agents/skill-validator-agent.md
-
-# Restart Claude Code if needed
-```
-
-### Command Not Found
-
-**Problem**: Slash command not recognized
-**Solution**:
-```bash
-# Verify command installation
-ls ~/.claude/commands/create-skill.md
-ls ~/.claude/commands/validate-skill.md
-ls ~/.claude/commands/list-skills.md
-
-# Restart Claude Code to reload commands
-```
-
-### Template Not Loading
-
-**Problem**: Template referenced but not found
-**Solution**:
-```bash
-# Verify templates installed
-ls ~/.claude/skills/
-
-# Should show:
-# - stakeholder-templates/
-# - ground-truth-template/
-# - product-context-template/
-# - initiative-overview-template/
-```
-
-### Validation Errors
-
-**Problem**: Skill validation reports errors
-**Solution**: Review the validation report for specific issues:
-- **PII detected**: Remove emails, phones, names
-- **Description quality low**: Add WHEN/WHEN NOT patterns
-- **Structure issues**: Check YAML frontmatter syntax
-- **Security concerns**: Review allowed-tools and confidential data
-
-## Integration with Other Tools
-
-### Works With
-
-- **Claude Code**: All versions with skill support
-- **Git**: Version control for skill files
-- **Markdown editors**: Edit skills with any markdown editor
-- **CI/CD**: Integrate `/validate-skill` in pipelines
-
-### Future Integrations
-
-- Marketplace publishing (when available)
-- Team collaboration features
-- Automated freshness checking
-- Usage analytics
-
-## Technical Details
-
-### Dependencies
-
-**Required**:
-- Claude Code with skills support
-- Read, Grep, Glob, TaskCreate, TaskUpdate, TaskGet, TaskList tools
-
-**Optional**:
-- Git (for version control)
-- jq (for JSON processing)
-
-### Compatibility
-
-- **Platform**: macOS, Linux, Windows (WSL)
-- **Claude Code Version**: All versions with skill support
-- **Shell**: bash, zsh
-
-### Performance
-
-- **Skill Creation**: ~2-5 minutes with interactive guidance
-- **Validation**: ~5-30 seconds per skill
-- **Template Loading**: Instant
-
-## Support & Contributing
-
-### Getting Help
-
-1. Review this README and troubleshooting section
-2. Check validation reports for specific guidance
-3. Review template examples and usage patterns
-4. Open an issue on GitHub (if applicable)
-
-### Reporting Issues
-
-When reporting issues, include:
-- Claude Code version
-- Operating system
-- Complete error message or validation report
-- Steps to reproduce
-- Expected vs actual behavior
-
-### Contributing
-
-Contributions welcome! Consider:
-- New skill templates
-- Validation improvements
-- Documentation enhancements
-- Bug fixes and optimizations
-
-## Version History
-
-Current: **v2.0.4** (2026-05-09).
-
-For full release notes across all versions see [CHANGELOG.md](./CHANGELOG.md).
-Highlights:
-
-- **v2.0.4** - flat plugin source layout (`skills/<name>/`, no more `skills/shared/` wrapper)
-- **v2.0.3** - alphabetised `plugin.json` arrays; `disable-model-invocation: true` on all four templates; cited Anthropic 250-char source in `marketplace-guidelines.md`
-- **v2.0.2** - canonical tools registry alignment in `agent-validator`; added missing `AskUserQuestion` to `skill-creator-agent`
-- **v2.0.1** - reverted (over-permissioning antipattern, see CHANGELOG)
-- **v2.0.0** - merged former agent-builder/editor/packager into `agent-author`, added `agent-validator`, `references/marketplace-guidelines.md`, 13 templates, `examples/`
-- **v1.0.0** - initial release
-
-## License
-
-MIT License - See LICENSE file for details
-
-## Credits
-
-**Created by**: Young Leaders Tech
-**Powered by**: Claude Code
-
----
-
-**Ready to create professional, production-ready Claude Code skills with automated validation and quality assurance.**
+See [CHANGELOG.md](./CHANGELOG.md) for full release notes.


### PR DESCRIPTION
## Summary
- README.md header said 3.1.0, but its own "Version History" footer said "Current: v2.0.4" - self-contradicting.
- The entire body still described the `/create-skill`, `/validate-skill`, `/list-skills` command-wrapper architecture that the Overview line itself says was replaced by the script-backed `skills-toolkit` skill in 3.0.0.
- Rewrote per the `ai-os-jc-toast` README standard (H1+one-line, what it does, getting started, skills table, architecture, how validation works, development, version footer), reading the actual current plugin structure first.
- Verified against `scripts/check_plugin_version_sync.py` (passes: VERSION/CHANGELOG/plugin.json/marketplace entry/README all agree on 3.1.0).

## Also surfaced (not fixed in this PR)
`skills/skills-toolkit/SKILL.md`'s own body text says the 4 legacy agents were "retired 2026-07-12" - but the 3.0.0 CHANGELOG entry and `plugin.json` agree only the 3 command wrappers were removed; the agents themselves were explicitly kept. Worth a follow-up wording fix in SKILL.md.

## Context
Found via `ai-os-jc-toast`'s validator-rebuild plan (Wave 17, T-490) while fixing a regex coverage gap in that repo's `C19-VERSION-DRIFT-ACROSS-MANIFESTS` check, which was blind to this exact self-drift pattern.

## Test plan
- [ ] Confirm the rewritten README accurately describes the current plugin (skills-toolkit skill, 4 shared templates, 4 legacy agents, templates/references/scripts/examples)
- [ ] Confirm `check_plugin_version_sync.py` passes (already verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)