### PR TITLE
enablement-html-renderer 1.5.1: complete 5-file version sync (fixes #39 drift)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "young-leaders-tech-marketplace",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Personal Claude Code plugin marketplace",
   "owner": {
     "name": "Young Leaders Tech",
@@ -40,7 +40,7 @@
     {
       "name": "enablement-html-renderer",
       "source": "./plugins/enablement-html-renderer",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "description": "Packages finished enablement material into one self-contained HTML file where the reader toggles format: bullets, prose, visual diagram, comic, or cheat sheet. Theme-aware diagrams, URL auto-linking, and an AI-ism voice gate."
     }
   ]

--- a/plugins/enablement-html-renderer/.claude-plugin/plugin.json
+++ b/plugins/enablement-html-renderer/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "description": "Packages finished enablement material (meeting summaries, workshop notes, training guides) into one self-contained HTML file where the reader toggles format: bullets, prose, visual diagram, comic, or cheat sheet. Theme-aware diagrams and an AI-ism voice gate. A handoff target, not a drafting tool.",
   "author": { "name": "Young Leaders Tech", "url": "https://youngleaders.tech" },
   "homepage": "https://github.com/YoungLeadersDotTech/young-leaders-tech-marketplace",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "skills": [
     "./skills/enablement-html-renderer"
   ]

--- a/plugins/enablement-html-renderer/README.md
+++ b/plugins/enablement-html-renderer/README.md
@@ -1,6 +1,6 @@
 # enablement-html-renderer
 
-**Version 1.5.0**
+**Version 1.5.1**
 
 Packages finished enablement material into one self-contained HTML file where the reader chooses
 the format. A handoff target, not a starting point: other skills (meeting, content-pipeline,


### PR DESCRIPTION
## What

Completes the 5-file version-sync for enablement-html-renderer 1.5.1. The spacing PR (#39) bumped only 3 of the 5 required files, leaving the plugin out of compliance with the marketplace version-sync rule enforced by `check_plugin_version_sync.py`.

## The rule

Per `plugins/skills-toolkit/scripts/check_plugin_version_sync.py`, any change inside `plugins/<name>/` must move all five in agreement:

1. `<plugin>/VERSION`
2. `<plugin>/CHANGELOG.md` (heading for the version)
3. `<plugin>/.claude-plugin/plugin.json` (`version`)
4. `.claude-plugin/marketplace.json` (this plugin's entry `version`, plus a top-level patch bump)
5. `<plugin>/README.md` (version header)

## What #39 already did

- VERSION -> 1.5.1
- CHANGELOG.md -> `## [1.5.1]` heading
- renderer-template.html (the actual spacing change)

## What this PR adds (the missing 3 of 5)

- `plugin.json` version 1.5.0 -> 1.5.1
- `marketplace.json`: enablement-html-renderer entry 1.5.0 -> 1.5.1, top-level 1.6.2 -> 1.6.3 (patch bump)
- `README.md` header `**Version 1.5.0**` -> `**Version 1.5.1**`

## Result

All five now name 1.5.1 (top-level marketplace 1.6.3), so `check_plugin_version_sync.py` passes. No functional change — this is metadata sync only.