### PR TITLE
fix: remove stale commands array from update-readme and terminal-setup-macos manifests

### DIFF
--- a/plugins/terminal-setup-macos/.claude-plugin/plugin.json
+++ b/plugins/terminal-setup-macos/.claude-plugin/plugin.json
@@ -6,10 +6,7 @@
     "url": "https://youngleaders.tech"
   },
   "homepage": "https://github.com/YoungLeadersDotTech/young-leaders-tech-marketplace",
-  "version": "1.3.0",
-  "commands": [
-    "./commands/terminal-setup-install.md"
-  ],
+  "version": "1.3.1",
   "skills": [
     "./skills/terminal-setup-install"
   ]

--- a/plugins/terminal-setup-macos/CHANGELOG.md
+++ b/plugins/terminal-setup-macos/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `terminal-setup-macos` are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-07-26
+
+### Fixed
+- `plugin.json` still declared a `commands` array pointing at `commands/terminal-setup-install.md`,
+  which 1.3.0 removed - the manifest and the actual file layout diverged, causing "Path not found"
+  on plugin load. Removed the stale `commands` entry; the plugin is skill-only via
+  `skills/terminal-setup-install`.
+
 ## [1.3.0] - 2026-07-12
 
 ### Removed

--- a/plugins/update-readme/.claude-plugin/plugin.json
+++ b/plugins/update-readme/.claude-plugin/plugin.json
@@ -6,10 +6,7 @@
     "url": "https://youngleaders.tech"
   },
   "homepage": "https://github.com/YoungLeadersDotTech/young-leaders-tech-marketplace",
-  "version": "1.2.0",
-  "commands": [
-    "./commands/update-readme.md"
-  ],
+  "version": "1.2.1",
   "skills": [
     "./skills/update-readme"
   ]

--- a/plugins/update-readme/CHANGELOG.md
+++ b/plugins/update-readme/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `update-readme` are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-07-26
+
+### Fixed
+- `plugin.json` still declared a `commands` array pointing at `commands/update-readme.md`, which
+  1.2.0 removed - the manifest and the actual file layout diverged, causing "Path not found" on
+  plugin load. Removed the stale `commands` entry; the plugin is skill-only via `skills/update-readme`.
+
 ## [1.2.0] - 2026-07-12
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Both `plugin.json` manifests still declared a `commands` array pointing at a `commands/*.md`
  wrapper file that a prior release (1.2.0 / 1.3.0) already removed in favour of skill-only
  invocation - the manifest and file layout diverged, causing "Path not found" on plugin load.
- Removed the stale `commands` entries, bumped patch versions (1.2.0->1.2.1, 1.3.0->1.3.1) with
  changelog entries.

## Test plan
- [x] Confirmed no `commands/` directory exists in either plugin - `skills/` is the only entry point
- [ ] `/reload-plugins` after merge - both plugins should load without error