### PR TITLE
Fix browser tab title showing __TITLE__ literally

### DIFF
--- a/plugins/enablement-html-renderer/skills/enablement-html-renderer/templates/renderer-template.html
+++ b/plugins/enablement-html-renderer/skills/enablement-html-renderer/templates/renderer-template.html
@@ -494,6 +494,7 @@ syncThemeBtn();
 // Deep-link: share file.html#prose to open straight into a chosen format.
 window.addEventListener("hashchange",()=> setFormat(location.hash.slice(1), false));
 
+document.title = DATA.title || document.title;
 document.getElementById("title").textContent = DATA.title||"";
 document.getElementById("kicker").textContent = (DATA.kind||"").toUpperCase();
 document.getElementById("coreidea").textContent = DATA.coreIdea||"";


### PR DESCRIPTION
Mirrors `ai-os-personal` PR #101. This repo is the public source-of-truth marketplace, so the fix needs to land here too, independently.

**Root cause:** `<title>__TITLE__</title>` in `<head>` was a raw placeholder never substituted. The runtime script only ever set the H1 heading (`id="title"`), never `document.title`, so the browser tab literally showed `__TITLE__`.

**Fix:** one line next to the existing title-setting line:
```js
document.title = DATA.title || document.title;
```

Passed em-dash, PII, leak, and JS-syntax gate checks before push. File size matches the pre-fix version plus exactly the one added line.